### PR TITLE
Update jitpack.yml (Fixes #150)

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -7,4 +7,5 @@ before_install:
 install:
   - if ! bash ensure-jitpack-java-17 use; then source ~/.sdkman/bin/sdkman-init.sh; fi
   - java -version
+  - chmod +x gradlew
   - ./gradlew publishToMavenLocal


### PR DESCRIPTION
There is a problem with your Jitpack configuration that I pointed out in issue #150.

This fixes the "permission denied" issue and guarantees that the gradlew file will be executable.